### PR TITLE
Fix font loading flash in animated text components

### DIFF
--- a/frontend/src/components/animations/CrumblingText.tsx
+++ b/frontend/src/components/animations/CrumblingText.tsx
@@ -22,13 +22,25 @@ const CrumblingText: React.FC<CrumblingTextProps> = ({
   useEffect(() => {
     if (typeof window === 'undefined' || !containerRef.current) return;
 
-    const ctx = gsap.context(() => {
-      // Set initial states with perspective for depth
-      gsap.set(containerRef.current, { 
-        opacity: 1,
-        perspective: 1000, // Add perspective for z-axis movement
-        transformStyle: 'preserve-3d'
-      });
+    // Wait for all fonts to load before starting animation
+    const startAnimation = async () => {
+      try {
+        // Wait for both Crimson Text (definition text) and Inter (pronunciation) to load
+        await Promise.all([
+          document.fonts.load('1rem "Crimson Text"'),
+          document.fonts.load('1rem "Inter"')
+        ]);
+      } catch (error) {
+        console.warn('Font loading timeout, proceeding with animation:', error);
+      }
+
+      const ctx = gsap.context(() => {
+        // Set initial states with perspective for depth
+        gsap.set(containerRef.current, {
+          opacity: 1,
+          perspective: 1000, // Add perspective for z-axis movement
+          transformStyle: 'preserve-3d'
+        });
       
       // Hide text elements with different initial states
       // Number "1." and both parts of definition 1 animate together from depth
@@ -73,9 +85,15 @@ const CrumblingText: React.FC<CrumblingTextProps> = ({
         },
         "-=0.4" // Overlap with text fade-in
       );
-    }, containerRef);
+      }, containerRef);
 
-    return () => ctx.revert();
+      return () => ctx.revert();
+    };
+
+    startAnimation();
+
+    // No cleanup needed for async function
+    return undefined;
   }, []);
 
   // Word animation effect (sbtl) - REMOVED typing animation, just show immediately

--- a/frontend/src/components/react/AnimatedDefinition.tsx
+++ b/frontend/src/components/react/AnimatedDefinition.tsx
@@ -18,9 +18,21 @@ const AnimatedDefinition: React.FC<AnimatedDefinitionProps> = ({
   useEffect(() => {
     if (typeof window === 'undefined' || !containerRef.current) return;
 
-    const ctx = gsap.context(() => {
-      // Show the container first
-      gsap.set(containerRef.current, { visibility: 'visible' });
+    // Wait for all fonts to load before starting animation
+    const startAnimation = async () => {
+      try {
+        // Wait for both Crimson Text (definition text) and Inter (pronunciation) to load
+        await Promise.all([
+          document.fonts.load('1rem "Crimson Text"'),
+          document.fonts.load('1rem "Inter"')
+        ]);
+      } catch (error) {
+        console.warn('Font loading timeout, proceeding with animation:', error);
+      }
+
+      const ctx = gsap.context(() => {
+        // Show the container first
+        gsap.set(containerRef.current, { visibility: 'visible' });
 
       // Split with smartWrap to prevent mid-word breaks
       const split1 = new SplitText(
@@ -87,13 +99,19 @@ const AnimatedDefinition: React.FC<AnimatedDefinitionProps> = ({
           totalTypingDuration - 0.4
         );
 
-      return () => {
-        split1.revert();
-        split2.revert();
-      };
-    }, containerRef);
+        return () => {
+          split1.revert();
+          split2.revert();
+        };
+      }, containerRef);
 
-    return () => ctx.revert();
+      return () => ctx.revert();
+    };
+
+    startAnimation();
+
+    // No cleanup needed for async function
+    return undefined;
   }, []);
 
   useEffect(() => {

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -28,21 +28,24 @@ const { title } = Astro.props;
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Preload critical fonts -->
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=block" as="style">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,700;1,400&display=block" as="style">
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=block" as="style">
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Mr+Dafoe&display=block" as="style">
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600&display=block" as="style">
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=M+PLUS+2:wght@400;500;700&display=block" as="style">
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=block" as="style">
-    
+
     <!-- Critical fonts - load immediately with display=block to prevent FOUT -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=block" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,700;1,400&display=block" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=block" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Mr+Dafoe&display=block" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600&display=block" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+2:wght@400;500;700&display=block" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=block" rel="stylesheet">
-    
+
     <!-- Non-critical fonts - load with display=swap -->
-    <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Sacramento&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Square+Peg&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Cantarell:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
@@ -60,6 +63,7 @@ const { title } = Astro.props;
 <style is:global>
   :root {
     /* Theme Fonts */
+    --font-inter: 'Inter', sans-serif;
     --font-cormorant: 'Cormorant Garamond', serif;
     --font-mplus: 'M PLUS 2', sans-serif;
     --font-abeezee: 'ABeeZee', sans-serif;


### PR DESCRIPTION
- Add Inter font to Layout (was missing but referenced in CSS)
- Move Crimson Text to critical fonts with display=block
- Wait for fonts to load before starting GSAP animations
- Prevents flash of fallback fonts during text animations